### PR TITLE
Add GitHub Actions R-cmd-check

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -58,7 +58,7 @@ jobs:
         run: Rscript -e "library(remotes)" -e "update(readRDS('depends.Rds'))" -e "remotes::install_cran('rcmdcheck')"
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual --no-build-vignettes', build_args = '--no-build-vignettes', error_on = 'error', check_dir = 'check')"
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = c('--no-manual','--no-vignettes'), build_args = '--no-build-vignettes', error_on = 'error', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -58,7 +58,7 @@ jobs:
         run: Rscript -e "library(remotes)" -e "update(readRDS('depends.Rds'))" -e "remotes::install_cran('rcmdcheck')"
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'error', check_dir = 'check')"
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual --no-build-vignettes', build_args = '--no-build-vignettes', error_on = 'error', check_dir = 'check')"
 
       - name: Upload check results
         if: failure()

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, r: '3.5'}
+        # - { os: macOS-latest, r: '3.5'}
         - { os: macOS-latest, r: 'release'}
         - { os: windows-latest, r: 'devel'}
 

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,0 +1,73 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - { os: macOS-latest, r: '3.5'}
+        - { os: macOS-latest, r: 'release'}
+        - { os: windows-latest, r: 'devel'}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      CRAN: ${{ matrix.config.cran }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds', version = 2)"
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        env:
+          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+        run: |
+          Rscript -e "remotes::install_github('r-hub/sysreqs')"
+          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
+          sudo -s eval "$sysreqs"
+      - name: Install dependencies
+        run: Rscript -e "library(remotes)" -e "update(readRDS('depends.Rds'))" -e "remotes::install_cran('rcmdcheck')"
+
+      - name: Check
+        run: Rscript -e "rcmdcheck::rcmdcheck(args = '--no-manual', error_on = 'error', check_dir = 'check')"
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check
+
+      # - name: Test coverage
+      #   if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
+      #   run: covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")
+      #   shell: Rscript {0}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Mendelian randomization with GWAS summary data
 
 <!-- badges: start -->
+[![Build Status](https://github.com/MRCIEU/TwoSampleMR/workflows/R-CMD-check/badge.svg)](https://github.com/MRCIEU/TwoSampleMR/actions?workflow=R-CMD-check)
 [![Travis build status](https://travis-ci.org/MRCIEU/TwoSampleMR.svg?branch=ieugwasr)](https://travis-ci.org/MRCIEU/TwoSampleMR) [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental) [![DOI](https://zenodo.org/badge/49515156.svg)](https://zenodo.org/badge/latestdoi/49515156)
 [![Codecov test coverage](https://codecov.io/gh/MRCIEU/TwoSampleMR/branch/ieugwasr/graph/badge.svg)](https://codecov.io/gh/MRCIEU/TwoSampleMR?branch=ieugwasr)
 <!-- badges: end -->


### PR DESCRIPTION
This is the GitHub Action I mentioned that have been using for `R CMD check`, i.e. as an alternative or in addition to Travis CI.

It is a copy with some minor changes of this by r-lib/actions [here](https://github.com/r-lib/actions/blob/master/examples/check-full.yaml). 

My changes are: 

- I commented out a check on R's oldrelease because you require at least R 3.6.0 - you probably want to maintain a compliance with the oldrelease if you can. Could you re-allow R 3.5.3?
- I changed the operating systems. I think it's faster to use Windows (although some packages still have to be built from source for R devel - and therefore the first run of that takes approx 30 mins) and macOS because R will be able to install compiled versions of the dependency packages. You/I can add some Ubuntu ones if you like.
 - In the `rcmdcheck()` call I changed `error_on = 'warning'` to `error_on = 'error'` to match your Travis check. In the long term it would better to use `'warning'`. And I excluded the building of the vignettes.
- I commented out the `Test coverage` action at the bottom as you're getting your coverage results from the Travis check.

I am hoping the aliases for R's `release` and `devel` versions will change automatically as the R version changes.

I have tested that this works. You can see the output [here](https://github.com/remlapmot/TwoSampleMR/actions?query=branch%3Aadd-github-actions-r-cmd-check+workflow%3AR-CMD-check) which will appear under your *Actions* tab if you accept.