### PR TITLE
Add R 3.6 back into Travis and GitHub Actions checks

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         config:
         # - { os: macOS-latest, r: '3.5'}
+        - { os: macOS-latest, r: '3.6'}
         - { os: macOS-latest, r: 'release'}
         - { os: windows-latest, r: 'devel'}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: r
 r:
+  - oldrel
   - release
   - devel
 cache: packages


### PR DESCRIPTION
Given that R-release is now at R 4.0.0 it seems worth running the checks on R 3.6 (one of whose patch versions will now be oldrel) as well as release and devel.