### PR TITLE
Fixed bug in mv_extract_exposures_local

### DIFF
--- a/R/multivariable_mr.R
+++ b/R/multivariable_mr.R
@@ -109,7 +109,7 @@ mv_extract_exposures_local <- function(filenames_exposure, sep = " ", phenotype_
 			min_pval = min_pval,
 			log_pval = log_pval
 		)
-		l_inst[[i]] <- subset(l_full[[i]], pval.exposure < pval_threshold)
+		l_inst[[i]] <- subset(l_full[[i]], pval.outcome < pval_threshold)
 		l_inst[[i]] <- convert_outcome_to_exposure(l_inst[[i]])
 		l_inst[[i]] <- clump_data(l_inst[[i]], clump_p1=pval_threshold, clump_r2=clump_r2, clump_kb=clump_kb)
 	}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mendelian randomization with GWAS summary data - Conor's Edits
+# Mendelian randomization with GWAS summary data
 
 <!-- badges: start -->
 [![Build Status](https://github.com/MRCIEU/TwoSampleMR/workflows/R-CMD-check/badge.svg)](https://github.com/MRCIEU/TwoSampleMR/actions?workflow=R-CMD-check)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mendelian randomization with GWAS summary data
+# Mendelian randomization with GWAS summary data - Conor's Edits
 
 <!-- badges: start -->
 [![Build Status](https://github.com/MRCIEU/TwoSampleMR/workflows/R-CMD-check/badge.svg)](https://github.com/MRCIEU/TwoSampleMR/actions?workflow=R-CMD-check)


### PR DESCRIPTION
Should be pval.outcome instead of pval.exposure.

l_full[[i]] column becomes pval.exposure after convert_outcome_to_exposure function but the subset happens before this.