### PR TITLE
Fix harmonise() for triallelic SNPs

### DIFF
--- a/R/harmonise.R
+++ b/R/harmonise.R
@@ -586,8 +586,7 @@ harmonise <- function(dat, tolerance, action)
 	d <- rbind(d21, d22, d12, d11)
 	d <- merge(d, dat, by="SNP", all.x=TRUE)
 	d$SNP <- d$orig_SNP
-  	d <- subset(d,select=-orig_SNP)		  
-	
+  	d <- subset(d,select=-orig_SNP)
 	d <- d[order(d$id.outcome), ]
 	d$mr_keep <- TRUE
 

--- a/R/harmonise.R
+++ b/R/harmonise.R
@@ -550,6 +550,9 @@ harmonise_11 <- function(SNP, A1, B1, betaA, betaB, fA, fB, tolerance, action)
 
 harmonise <- function(dat, tolerance, action)
 {
+	dat$orig_SNP<-dat$SNP
+  	SNP_index<-sapply(1:length(dat$SNP),function(i)sum(dat$SNP[1:i]==dat$SNP[i]))
+  	dat$SNP<-paste0(dat$SNP,"_",SNP_index)
 	SNP <- dat$SNP
 	A1 <- dat$effect_allele.exposure
 	A2 <- dat$other_allele.exposure
@@ -582,6 +585,9 @@ harmonise <- function(dat, tolerance, action)
 
 	d <- rbind(d21, d22, d12, d11)
 	d <- merge(d, dat, by="SNP", all.x=TRUE)
+	d$SNP <- d$orig_SNP
+  	d <- subset(d,select=-orig_SNP)		  
+	
 	d <- d[order(d$id.outcome), ]
 	d$mr_keep <- TRUE
 


### PR DESCRIPTION
When there are multiple variants present for a single SNP, the harmonise function had a small bug where it would duplicate them and attach information related to the other variant. (E.g. SNP rs11177669 using outcome "ukb-b-2227" and exposure "ieu-a-89"). This fix attempts to solve this by creating a new ID for each SNP based on how many variants there are in the dataset. The new ID is removed once the harmonisation is complete.