### PR TITLE
R-CMD-check GitHub action: move jobs from Ubuntu 16.04 to 18.04 and other edits

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches:
-      - master
+    # branches:
+    #   - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -69,7 +69,3 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
-      # - name: Test coverage
-      #   if: matrix.config.os == 'macOS-latest' && matrix.config.r == '3.6'
-      #   run: covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")
-      #   shell: Rscript {0}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: ubuntu-16.04, r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
         - { os: macOS-latest, r: 'release'}
         - { os: ubuntu-16.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+        - {os: ubuntu-18.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -21,6 +21,8 @@ jobs:
         - {os: ubuntu-18.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
         - {os: ubuntu-18.04,   r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
         - {os: macOS-latest,   r: 'release'}
+        - {os: windows-latest, r: 'release'}
+        - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
         - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
 
     env:

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         config:
         - {os: ubuntu-18.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+        - {os: ubuntu-18.04,   r: 'oldrel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
         - {os: macOS-latest,   r: 'release'}
         - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
 

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        # - { os: macOS-latest, r: '3.5'}
-        # - { os: macOS-latest, r: '3.6'}
         - { os: ubuntu-16.04, r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
         - { os: macOS-latest, r: 'release'}
         - { os: ubuntu-16.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -27,6 +27,7 @@ jobs:
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      RSPM: ${{ matrix.config.rspm }}
       CRAN: ${{ matrix.config.cran }}
 
     steps:
@@ -35,33 +36,57 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
 
       - uses: r-lib/actions/setup-pandoc@master
 
       - name: Query dependencies
-        run: Rscript -e "install.packages('remotes')" -e "saveRDS(remotes::dev_package_deps(dependencies = TRUE), 'depends.Rds', version = 2)"
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v1
+      - name: Restore R package cache
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{ hashFiles('depends.Rds') }}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
-        env:
-          RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
         run: |
-          Rscript -e "remotes::install_github('r-hub/sysreqs')"
-          sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
-          sudo -s eval "$sysreqs"
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "18.04"))')
+
       - name: Install dependencies
-        run: Rscript -e "library(remotes)" -e "update(readRDS('depends.Rds'))" -e "remotes::install_cran('rcmdcheck')"
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
 
       - name: Check
-        run: Rscript -e "rcmdcheck::rcmdcheck(args = c('--no-manual'), error_on = 'error', check_dir = 'check')"
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: |
+          options(crayon.enabled = TRUE)
+          rcmdcheck::rcmdcheck(args = c('--no-manual', '--as-cran'), error_on = 'error', check_dir = 'check')
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
 
       - name: Upload check results
         if: failure()
@@ -70,3 +95,7 @@ jobs:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check
 
+      - name: Don't use tar from old Rtools to store the cache
+        if: ${{ runner.os == 'Windows' && startsWith(steps.install-r.outputs.installed-r-version, '3.6' ) }}
+        shell: bash
+        run: echo "C:/Program Files/Git/usr/bin" >> $GITHUB_PATH

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-        - { os: macOS-latest, r: 'release'}
         - {os: ubuntu-18.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+        - {os: macOS-latest,   r: 'release'}
         - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
 
     env:

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         config:
         - { os: macOS-latest, r: 'release'}
-        - { os: ubuntu-16.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
         - {os: ubuntu-18.04,   r: '3.6', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+        - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.0.0 (ubuntu-18.04) R (4.0.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -1,7 +1,7 @@
 on:
   push:
-    # branches:
-    #   - master
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
* Switch jobs from `ubuntu-16.04` to `ubuntu-18.04` as `ubuntu-16.04` will soon no longer work as per the announcement [here](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/)
* Additional edits following r-lib/actions/examples/check-full.yaml [here](https://github.com/r-lib/actions/blob/630f4c9d8b813f45d0327a2fc20eb264fd518450/examples/check-full.yaml)