### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.css linguist-vendored
 *.js linguist-vendored
 docs/* linguist-vendored
+*.rdb linguist-vendored
+*.rdx linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Settings for Linguist Languages pane
+*.html linguist-vendored
+*.css linguist-vendored
+*.js linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.html linguist-vendored
 *.css linguist-vendored
 *.js linguist-vendored
+docs/* linguist-vendored


### PR DESCRIPTION
This should make the Languages pane on GitHub ignore the `.html`, `.css`, and `.js` files and the files in the `docs` directory when calculating its Languages statistics, and therefore show the main language of the repo as R.