### PR TITLE
Fix car dependency issue

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, randomForest=?ignore-before-r=4.1.0
+          extra-packages: any::rcmdcheck, randomForest=?ignore-before-r=4.1.0, car=?ignore-before-r=4.1.0
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,4 +65,4 @@ Remotes:
     WSpiller/RadialMR
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ License: MIT + file LICENSE
 Depends:
     R (>= 4.0.0)
 Imports:
-    car,
     cowplot,
     data.table,
     dplyr,
@@ -51,6 +50,7 @@ Imports:
     rmarkdown
 Suggests: 
     Cairo,
+    car,
     markdown,
     MRInstruments,
     randomForest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ TwoSampleMR v0.5.7 (Release date: TBC)
 
 Changes:
 
+* Move car package to Suggests to allow TwoSampleMR to install on R between versions 4.0.0 and 4.1.0
 * Various minor code tweaks to fix 2 R CMD check notes
 * Add Cairo package to Suggests list (thanks @hdraisma)
 * Fix error in outcome data vignette (thanks @hdraisma)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ TwoSampleMR v0.5.7 (Release date: TBC)
 Changes:
 
 * Move car package to Suggests to allow TwoSampleMR to install on R between versions 4.0.0 and 4.1.0
+* In DESCRIPTION use pkgdepends syntax for MRPRESSO package due its repository name being different to the package name so that installing TwoSampleMR under pak continues to work
 * Various minor code tweaks to fix 2 R CMD check notes
 * Add Cairo package to Suggests list (thanks @hdraisma)
 * Fix error in outcome data vignette (thanks @hdraisma)

--- a/R/moe.R
+++ b/R/moe.R
@@ -58,6 +58,12 @@ system_metrics <- function(dat)
 		metrics$cooks_egger <- sum(inf2[,4] > cooksthresh2) / nrow(dat)
 
 		# Homoscedasticity
+		if (!requireNamespace("car", quietly = TRUE)) {
+		  stop(
+		    "Package \"car\" must be installed to use this function.",
+		    call. = FALSE
+		  )
+		}
 		metrics$homosc_ivw <- car::ncvTest(ruck$lmod_ivw)$ChiSquare
 		metrics$homosc_egg <- car::ncvTest(ruck$lmod_egger)$ChiSquare
 

--- a/tests/testthat/test_eve.R
+++ b/tests/testthat/test_eve.R
@@ -4,6 +4,7 @@ library(TwoSampleMR)
 dat <- make_dat("ieu-a-2", "ieu-a-7") %>% add_metadata()
 
 test_that("wrapper", {
+  skip_if_not_installed("car")
 	expect_warning(w <- mr_wrapper(dat))
 	expect_true(length(w) == 1)
 	expect_true(length(names(w[[1]])) == 5)


### PR DESCRIPTION
This fixes the `R CMD check` failure on oldrel-2 yesterday, which was caused by one of the dependencies of the car package, the pbkrtest package now requiring R version >= 4.1.0.

I could have just fixed this in `check-full.yaml`, but seeing as the car package was only used in 2 places in the code I have moved it from Imports to Suggests - because we need to shorten our Imports list whenever possible (ideally get it to 20 packages or fewer eventually).

Also, I bumped roxygen2 version number to latest version, and added a bullet to `NEWS` I forgot to add last time.

Happy to chat on a video call if needed (just to say I am involved with teaching today).