### PR TITLE
Add alt text descriptions to images and figures in vignettes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@ Changes:
 * Updating default rsq estimation function to use beta and standard error instead of p-value, should improve numerical stability
 * Allow chr and pos to be read in from local summary data files
 * When reading in local data without p-values, editing the inferred p-value method to be two-sided
+* All images in the vignettes (and hence also in the rendered pkgdown website) now have accompanying alt text descriptions
 
 TwoSampleMR v0.5.6 (Release date: 2021-03-25)
 ==============

--- a/vignettes/gwas2020.Rmd
+++ b/vignettes/gwas2020.Rmd
@@ -139,4 +139,3 @@ We recommend using this new version going forwards but for a limited time we are
 install.packages("remotes")
 remotes::install_github("MRCIEU/TwoSampleMR@0.4.26")
 ```
-

--- a/vignettes/harmonise.Rmd
+++ b/vignettes/harmonise.Rmd
@@ -30,7 +30,7 @@ suppressWarnings(suppressPackageStartupMessages(library(knitr)))
 
 The exposure data and outcome data are now obtained, e.g.:
 
-```{r }
+```{r}
 ao <- available_outcomes()
 bmi_exp_dat <- extract_instruments(outcomes = 'ieu-a-2')
 chd_out_dat <- extract_outcome_data(snps = bmi_exp_dat$SNP, outcomes = 'ieu-a-7')
@@ -42,7 +42,7 @@ but it is important to harmonise the effects. This means that the effect of a SN
 
 To harmonise the exposure and outcome data, do the following:
 
-```{r }
+```{r}
 dat <- harmonise_data(
 	exposure_dat = bmi_exp_dat, 
 	outcome_dat = chd_out_dat

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -65,7 +65,7 @@ The workflow for performing MR is as follows:
 A diagrammatic overview is shown here:
 
 
-<img src="https://drive.google.com/uc?id=1yHTkn-kVqZzsQfQdXBHZBGdFWj8gSsPQ" width="800"/>
+<img alt="A diagrammatic overview of performing a two-sample Mendelian randomization analysis" src="https://drive.google.com/uc?id=1yHTkn-kVqZzsQfQdXBHZBGdFWj8gSsPQ" width="800"/>
 
 
 A basic analysis, e.g. the causal effect of body mass index on coronary heart disease, looks like this:

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -64,9 +64,7 @@ The workflow for performing MR is as follows:
 
 A diagrammatic overview is shown here:
 
-
 <img alt="A diagrammatic overview of performing a two-sample Mendelian randomization analysis" src="https://drive.google.com/uc?id=1yHTkn-kVqZzsQfQdXBHZBGdFWj8gSsPQ" width="800"/>
-
 
 A basic analysis, e.g. the causal effect of body mass index on coronary heart disease, looks like this:
 
@@ -100,7 +98,5 @@ Each step is documented on other pages in the documentation.
 
 Detailed information is given here: [https://github.com/MRCIEU/ieugwasr/blob/master/README.md#authentication](https://github.com/MRCIEU/ieugwasr/blob/master/README.md#authentication)
 
-
 ## References
-
 <br/>

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -62,7 +62,7 @@ The workflow for performing MR is as follows:
 3. Harmonise the effect sizes for the instruments on the exposures and the outcomes to be each for the same reference allele
 4. Perform MR analysis, sensitivity analyses, create plots, compile reports
 
-A diagramatic overview is shown here:
+A diagrammatic overview is shown here:
 
 
 <img src="https://drive.google.com/uc?id=1yHTkn-kVqZzsQfQdXBHZBGdFWj8gSsPQ" width="800"/>

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -99,4 +99,3 @@ Each step is documented on other pages in the documentation.
 Detailed information is given here: [https://github.com/MRCIEU/ieugwasr/blob/master/README.md#authentication](https://github.com/MRCIEU/ieugwasr/blob/master/README.md#authentication)
 
 ## References
-<br/>

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -196,7 +196,7 @@ p2[[1]]
 
 Use the `mr_leaveoneout_plot()` function to visualise the leave-one-out analysis:
 
-```{r}
+```{r fig.alt="A leave one out plot showing the Inverse Variance Weighted estimate with each SNP omitted."}
 res_loo <- mr_leaveoneout(dat)
 p3 <- mr_leaveoneout_plot(res_loo)
 p3[[1]]

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -505,7 +505,7 @@ This is an implementation of the method described here:
 **Orienting the causal relationship between imprecisely measured traits using GWAS summary data.**<br/>
 PLoS Genetics. 2017. 13(11).](http://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1007081)
 
-In MR it is assumed that the instruments influence the exposure first and then the outcome through the exposure. But sometimes this is difficult to evaluate, for example is a cis-acting SNP influencing gene expression levels or DNA methylation levels first? The causal direction between the hypothesised exposure and outcomes can be tested using the Steiger test [reference to go here]. For example:
+In MR it is assumed that the instruments influence the exposure first and then the outcome through the exposure. But sometimes this is difficult to evaluate, for example is a cis-acting SNP influencing gene expression levels or DNA methylation levels first? The causal direction between the hypothesised exposure and outcomes can be tested using the Steiger test [@hemani-plosgen-2017]. For example:
 
 ```{r}
 out <- directionality_test(dat)
@@ -780,3 +780,5 @@ head(all_res[, c(
 ```
 
 This combines all results from `mr()`, `mr_heterogeneity()`, `mr_pleiotropy_test()` and `mr_singlesnp()` into a single dataframe. It also merges the results with outcome study level characteristics from the `available_outcomes()` function, including sample size characteristics. If requested, it also exponentiates results (e.g. if the user wants log odds ratio converted into odds ratios with 95 percent confidence intervals). 
+
+## References

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -194,7 +194,7 @@ p2[[1]]
 
 ### Leave-one-out plot
 
-Use the `mr_leaveoneout_plot` function to visualise the leave-one-out analysis:
+Use the `mr_leaveoneout_plot()` function to visualise the leave-one-out analysis:
 
 ```{r}
 res_loo <- mr_leaveoneout(dat)

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -415,7 +415,7 @@ res <- split_outcome(res) # to keep the Y axis label clean we exclude the exposu
 res <- sort_1_to_many(res, b = "b", sort_action = 4) #this sorts results by decreasing effect size (largest effect at top of the plot)
 ```
 
-MR results for 103 diseases can be difficult to visualise in a single-column forest plot. In my own workflow I would split these across two plots and then join them together in a separate program, such as powerpoint, and do further refinements there. I typically save my plots using the pdf() graphics device. In this particular example the disease labels probably require some cleaning up (some are a bit long) or alternatively the column text size could be made smaller. It is also possible to change the colour of the plot and the shape of the point estimates. Type ?forest_plot_1_to_many for further details.
+MR results for 103 diseases can be difficult to visualise in a single-column forest plot. In my own workflow I would split these across two plots and then join them together in a separate program, such as Powerpoint, and do further refinements there. I typically save my plots using the `pdf()` graphics device. In this particular example the disease labels probably require some cleaning up (some are a bit long) or alternatively the column text size could be made smaller. It is also possible to change the colour of the plot and the shape of the point estimates. Type `?forest_plot_1_to_many` for further details.
 
 ```{r cache=TRUE, warning=FALSE, fig.height=10, eval=FALSE}
 res1 <- res[1:52, ]

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -693,7 +693,8 @@ The result object itself is a list with the following elements:
 - `directional_pleiotropy` (egger intercepts)
 - `info` (metrics used to generate MOE)
 
-Looking at the `estimates`, we see that there is a column called `MOE` which is the predicted AUROC curve performance of each method. 
+Looking at the `estimates`, we see that there is a column called `MOE` which is the predicted AUROC curve performance of each method.
+
 * * *
 
 ## Post MR results management 

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -208,7 +208,8 @@ Specify the test to use e.g. `mr_leaveoneout(dat, method = mr_egger_regression)`
 ### Funnel plot
 
 Asymmetry in a funnel plot is useful for gauging the reliability of a particular MR analysis. Funnel plots can be produced using the single SNP results as follows:
-```{r}
+
+```{r fig.alt="A funnel plot showing the causal effect for each SNP and the inverse variance weighted and MR-Egger estimates using all the SNPs."}
 res_single <- mr_singlesnp(dat)
 p4 <- mr_funnel_plot(res_single)
 p4[[1]]

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -186,7 +186,7 @@ Here, the plot shows the causal effect as estimated using each of the SNPs on th
 
 To get plots that use different methods, specify them in the `mr_singlesnp()` function:
 
-```{r}
+```{r fig.alt="An alternative forest plot showing the estimated causal effects using each SNP separately, and the Inverse Variance Weighted and Maximum Likelihood estimates using all the SNPs."}
 res_single <- mr_singlesnp(dat, all_method = c("mr_ivw", "mr_two_sample_ml"))
 p2 <- mr_forest_plot(res_single)
 p2[[1]]

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -471,7 +471,7 @@ MR.RAPS is implemented in the R package _mr.raps_ that is available on CRAN. It 
 res <- mr(dat, method_list = c("mr_raps"))
 ```
 
-MR.RAPS comes with two main options: _over.dispersion_ (whether the method should consider systematic pleiotropy) and _loss.function_ (either "l2", "huber", or "tukey"). The latter two loss functions are robust to idiosyncratic pleiotropy. The default option is _over.dispersion = TRUE_ and _loss.function = "tukey"_. To change these options, modify the _parameters_ argument of _mr_ by (for example)
+MR.RAPS comes with two main options: `over.dispersion` (whether the method should consider systematic pleiotropy) and `loss.function` (either `"l2"`, `"huber"`, or `"tukey"`). The latter two loss functions are robust to idiosyncratic pleiotropy. The default option is `over.dispersion = TRUE` and `loss.function = "tukey"`. To change these options, modify the `parameters` argument of `mr()` by (for example)
 ```{r eval=FALSE}
 res <-
   mr(

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -141,7 +141,7 @@ p1 <- mr_scatter_plot(res, dat)
 
 A scatter plot is created for each exposure-outcome test, and stored in `p1` as a list of plots. For example, to plot the first scatter plot:
 
-```{r}
+```{r fig.alt="A scatter plot visualising the two-sample data points and the following fitted models; Inverse Variance Weighted, MR-Egger, Simple mode, Weighted median, and Weighted mode."}
 p1[[1]]
 ```
 

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -82,7 +82,6 @@ As with the `mr()` function, the `mr_heterogeneity()` function can take an argum
 mr_heterogeneity(dat, method_list = c("mr_egger_regression", "mr_ivw"))
 ```
 
-
 ### Horizontal pleiotropy
 
 The intercept term in MR Egger regression can be a useful indication of whether directional horizontal pleiotropy is driving the results of an MR analysis. This can be obtained as follows:
@@ -90,7 +89,6 @@ The intercept term in MR Egger regression can be a useful indication of whether 
 ```{r}
 mr_pleiotropy_test(dat)
 ```
-
 
 ### Single SNP analysis
 
@@ -116,7 +114,6 @@ res_single <- mr_singlesnp(dat, all_method = "mr_two_sample_ml")
 
 will perform only the maximum likelihood method for the combined test.
 
-
 ### Leave-one-out analysis
 
 It is possible to perform a leave-one-out analysis, where the MR is performed again but leaving out each SNP in turn, to identify if a single SNP is driving the association.
@@ -132,7 +129,6 @@ By default the method used is the inverse variance weighted method, but this can
 ## Plots
 
 There are a few ways to visualise the results, listed below
-
 
 ### Scatter plot
 
@@ -175,7 +171,6 @@ ggsave(p1[[1]], file = "filename.png", width = 7, height = 7)
 ```
 
 See `?ggplot2::ggsave` for more info.
-
 
 ### Forest plot
 
@@ -393,7 +388,6 @@ forest_plot_1_to_many(
 
 In the above example we made up an arbitrary grouping variable called "subcategory" with values "Group 1" and "Group 2". Typically, however, the grouping variable might correspond to something like a trait ontology (e.g. anthropometric and glycemic traits) or study design (e.g. MR and observational studies). 
 
-
 #### Example 4. Effect of BMI on 103 diseases 
 
 The plot function works best with 50 or fewer rows and is not really designed to handle more than a 100. Visualising a single-column forest plot with 100 results is also quite difficult. If your number of results is much greater than 50, it is advisable to split the results across two different plots. In the example below we select BMI as the exposure and test this against 103 diseases in the IEU GWAS database:
@@ -561,7 +555,6 @@ id_outcome <- "ieu-a-7"
 ```
 
 First obtain the instruments for each lipid fraction. This entails obtaining a combined set of SNPs including all instruments, and getting those SNPs for each lipid fraction. Therefore, if there are e.g. 20 instruments for each of 3 lipid fractions, but combined there are 30 unique SNPs, then we need to extract each of the 30 SNPs from each lipid fraction (exposure). 
-
 
 ```{r eval=FALSE}
 exposure_dat <- mv_extract_exposures(id_exposure)

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -176,7 +176,7 @@ See `?ggplot2::ggsave` for more info.
 
 Use the `mr_forest_plot()` function to compare the MR estimates using the different MR methods against the single SNP tests.
 
-```{r }
+```{r fig.alt="A forest plot showing the estimated causal effects using each SNP separately, and the Inverse Variance Weighted and MR-Egger estimates using all the SNPs."}
 res_single <- mr_singlesnp(dat)
 p2 <- mr_forest_plot(res_single)
 p2[[1]]

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -208,7 +208,6 @@ Specify the test to use e.g. `mr_leaveoneout(dat, method = mr_egger_regression)`
 ### Funnel plot
 
 Asymmetry in a funnel plot is useful for gauging the reliability of a particular MR analysis. Funnel plots can be produced using the single SNP results as follows:
-howzit
 ```{r}
 res_single <- mr_singlesnp(dat)
 p4 <- mr_funnel_plot(res_single)

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -592,13 +592,13 @@ With these three different parameters there are eight different ways to do MV an
 
 ### Note about visualisation
 
-Plots can be generated using the `plots=TRUE` argument for `mv_multiple` and `mv_residual`. 
+Plots can be generated using the `plots = TRUE` argument for `mv_multiple()` and `mv_residual()`. 
 
 The current plots being generated are not necessarily adequate because while they show the slope through the raw points, they do not demonstrate that the raw points might be effectively different between plots because they are conditional on the other exposures. 
 
 ### Using your own summary data
 
-If you want to perform analysis with your local summary data (i.e. not in the OpenGWAS database) then use then look up the `mv_extract_exposures_local` function in replace of the `mv_extract_exposures` function.
+If you want to perform analysis with your local summary data (i.e. not in the OpenGWAS database) then use then look up the `mv_extract_exposures_local()` function in replace of the `mv_extract_exposures()` function.
 
 * * *
 
@@ -613,7 +613,7 @@ snplist <- c("rs234", "rs1205")
 ld_matrix(snplist)
 ```
 
-Here `ld_matrix` returns the LD correlation values (not R^2) for each pair of variants present in the 1000 genomes data set.
+Here `ld_matrix()` returns the LD correlation values (not R^2^) for each pair of variants present in the 1000 genomes data set.
 
 ```{r eval=FALSE}
 dat <- harmonise_data(
@@ -655,7 +655,7 @@ In order to run the analysis you must download an RData object that contains the
 
 **Caution: this is a large file (approx 167Mb)**
 
-Once downloaded, read in the object and use the `mr_moe` function to perform the analysis. An example is shown here, estimating the causal effect of BMI on coronary heart disease:
+Once downloaded, read in the object and use the `mr_moe()` function to perform the analysis. An example is shown here, estimating the causal effect of BMI on coronary heart disease:
 
 ```{r eval=FALSE}
 # Extact instruments for BMI
@@ -680,7 +680,7 @@ res_moe <- mr_moe(res, rf)
 The function does the following:
 
 1. Performs MR using each of 11 MR methods
-2. Applies Steiger filtering or heterogeneity filtering or both to remove SNPs that do not have substantially larger R^2 with the exposure than the outcome. Note - for binary traits ensure number of cases, number of controls, and allele frequencies are available for each SNP. For continuous traits make sure the p-value and sample size is available. The function infers if a trait is binary or continuous based on the units.exposure and units.outcome columns - binary traits must have those values set to 'log odds'
+2. Applies Steiger filtering or heterogeneity filtering or both to remove SNPs that do not have substantially larger R^2^ with the exposure than the outcome. Note - for binary traits ensure number of cases, number of controls, and allele frequencies are available for each SNP. For continuous traits make sure the p-value and sample size is available. The function infers if a trait is binary or continuous based on the units.exposure and units.outcome columns - binary traits must have those values set to 'log odds'
 3. Performs the 14 MR methods again but using the subset of SNPs that survive Steiger filtering
 4. Generates meta data about the summary data to predict the most reliable of the 28 methods applied.
 

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -584,7 +584,7 @@ This generates a table of results.
 
 There are several different ways in which this analysis can be formulated. e.g. consider 3 exposures against one outcome, one could:
 
-1. Fit all exposures together or fit one exposure at a time against the residuals of the outcome that has been adjusted for the other outcomes. The former is recommended by default in this R package through the `mv_multiple` function but the latter was how MV MR was originally described by Burgess et al 2015 and can be done with `mv_residual`.
+1. Fit all exposures together or fit one exposure at a time against the residuals of the outcome that has been adjusted for the other outcomes. The former is recommended by default in this R package through the `mv_multiple()` function but the latter was how MV MR was originally described by Burgess et al 2015 and can be done with `mv_residual()`.
 2. Fitting all instruments for all exposures (default) or only fitting the instruments for each exposure sequentially
 3. Forcing the slopes through the origin (default) or allowing an intercept term.
 

--- a/vignettes/refs.bib
+++ b/vignettes/refs.bib
@@ -73,3 +73,18 @@
     year = {2010},
 }
 
+@article{hemani-plosgen-2017,
+    doi = {10.1371/journal.pgen.1007081},
+    author = {Hemani, Gibran and Tilling, Kate and Davey Smith, George},
+    journal = {PLOS Genetics},
+    publisher = {Public Library of Science},
+    title = {Orienting the causal relationship between imprecisely measured traits using GWAS summary data},
+    year = {2017},
+    number = {11},
+    volume = {13},
+    url = {https://doi.org/10.1371/journal.pgen.1007081},
+    pages = {e1007081},
+    abstract = {Inference about the causal structure that induces correlations between two traits can be achieved by combining genetic associations with a mediation-based approach, as is done in the causal inference test (CIT). However, we show that measurement error in the phenotypes can lead to the CIT inferring the wrong causal direction, and that increasing sample sizes has the adverse effect of increasing confidence in the wrong answer. This problem is likely to be general to other mediation-based approaches. Here we introduce an extension to Mendelian randomisation, a method that uses genetic associations in an instrumentation framework, that enables inference of the causal direction between traits, with some advantages. First, it can be performed using only summary level data from genome-wide association studies; second, it is less susceptible to bias in the presence of measurement error or unmeasured confounding. We apply the method to infer the causal direction between DNA methylation and gene expression levels. Our results demonstrate that, in general, DNA methylation is more likely to be the causal factor, but this result is highly susceptible to bias induced by systematic differences in measurement error between the platforms, and by horizontal pleiotropy. We emphasise that, where possible, implementing MR and appropriate sensitivity analyses alongside other approaches such as CIT is important to triangulate reliable conclusions about causality.},
+    number = {11},
+
+}


### PR DESCRIPTION
This,
* adds alt text to the images and figures in the vignettes, and hence to the pkgdown site
* various other fixes to typos and other formatting I spotted whilst adding the alt text
