### PR TITLE
Release 0.5.7

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -5,7 +5,7 @@ on:
     branches: [main, master]
   workflow_dispatch:
   schedule:
-    - cron: '37 7 * * MON' # run at 7:37am UTC on Mondays
+    - cron: '37 2 * * TUE' # run at 7:37am UTC on Mondays
 
 name: R-CMD-check
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: false
           branch: gh-pages

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -22,7 +22,7 @@ authors:
 title: "TwoSampleMR R package"
 type: software
 version: 0.5.7
-date-released: 2021-03-25
+date-released: 2023-05-29
 doi: "10.5281/zenodo.4636570"
 url: "https://mrcieu.github.io/TwoSampleMR/index.html"
 repository-code: "https://github.com/MRCIEU/TwoSampleMR"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,7 +21,7 @@ authors:
   orcid: "https://orcid.org/0000-0003-4655-4511"
 title: "TwoSampleMR R package"
 type: software
-version: 0.5.6
+version: 0.5.7
 date-released: 2021-03-25
 doi: "10.5281/zenodo.4636570"
 url: "https://mrcieu.github.io/TwoSampleMR/index.html"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MR Base Database
-Version: 0.5.6
+Version: 0.5.7
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 TwoSampleMR v0.5.7 
 ==============
 
-(Release date: TBC)
+(Release date: 2023-05-29)
 
 * Move car package to Suggests to allow TwoSampleMR to install on R between versions 4.0.0 and 4.1.0
 * In DESCRIPTION use pkgdepends syntax for MRPRESSO package due its repository name being different to the package name so that installing TwoSampleMR under pak continues to work


### PR DESCRIPTION
This bumps the version number and associated date and 

* bumps the JamesIves GHA workflow to use v4 sliding tag
* amends the CRON job to run `R CMD check` very early on a Tuesday morning