### PR TITLE
removing google oauth2 authentication and replacing with opengwas jwt

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -31,6 +31,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      OPENGWAS_X_TEST_MODE_KEY: ${{ secrets.OPENGWAS_X_TEST_MODE_KEY }}
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +51,11 @@ jobs:
             randomForest=?ignore-before-r=4.1.0,
             car=?ignore-before-r=4.1.0,
           needs: check
+
+      - name: Create and populate .Renviron file
+        run: |
+          echo OPENGWAS_X_TEST_MODE_KEY="$OPENGWAS_X_TEST_MODE_KEY" >> ~/.Renviron
+        shell: bash
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      OPENGWAS_X_TEST_MODE_KEY: ${{ secrets.OPENGWAS_X_TEST_MODE_KEY }}
     steps:
       - uses: actions/checkout@v4
 
@@ -23,6 +24,11 @@ jobs:
         with:
           extra-packages: any::covr
           needs: coverage
+
+      - name: Create and populate .Renviron file
+        run: |
+          echo OPENGWAS_X_TEST_MODE_KEY="$OPENGWAS_X_TEST_MODE_KEY" >> ~/.Renviron
+        shell: bash
 
       - name: Test coverage
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
+    MRCIEU/ieugwasr,
     gqi/MRMix,
     mrcieu/MRInstruments,
     MRPRESSO=rondolab/MR-PRESSO,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MR Base Database
-Version: 0.5.11
+Version: 0.6.0
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),
@@ -36,7 +36,7 @@ Imports:
     glmnet,
     gridExtra,
     gtable,
-    ieugwasr (>= 0.1.5),
+    ieugwasr (>= 1.0.0),
     knitr,
     lattice,
     magrittr,
@@ -63,7 +63,6 @@ VignetteBuilder:
     knitr
 Remotes:
     gqi/MRMix,
-    mrcieu/ieugwasr,
     mrcieu/MRInstruments,
     MRPRESSO=rondolab/MR-PRESSO,
     WSpiller/RadialMR

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    MRCIEU/ieugwasr,
     gqi/MRMix,
     mrcieu/MRInstruments,
     MRPRESSO=rondolab/MR-PRESSO,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TwoSampleMR v0.6.0
+
+(Release date: 2024-04-22)
+
+* TwoSampleMR now uses the CRAN version of the **ieugwasr** package. Importantly this includes the new authentication system for the OpenGWAS API. Please see <https://mrcieu.github.io/ieugwasr/articles/guide.html#authentication> for more information about how to set this up.
+
 # TwoSampleMR v0.5.11
 
 (Release date: 2024-03-21)

--- a/R/instruments.R
+++ b/R/instruments.R
@@ -9,17 +9,17 @@
 #' @param p2 Secondary clumping threshold. The default is `5e-8`.
 #' @param r2 Clumping r2 cut off. The default is `0.001`.
 #' @param kb Clumping distance cutoff. The default is `10000`.
-#' @param access_token Google OAuth2 access token. Used to authenticate level of access to data. The default is [ieugwasr::check_access_token()].
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param force_server Force the analysis to extract results from the server rather than the MRInstruments package.
 #'
 #' @export
 #' @return data frame
-extract_instruments <- function(outcomes, p1 = 5e-8, clump = TRUE, p2 = 5e-8, r2 = 0.001, kb = 10000, access_token = ieugwasr::check_access_token(), force_server=FALSE)
+extract_instruments <- function(outcomes, p1 = 5e-8, clump = TRUE, p2 = 5e-8, r2 = 0.001, kb = 10000, opengwas_jwt=ieugwasr::get_opengwas_jwt(), force_server=FALSE)
 {
 	# .Deprecated("ieugwasr::tophits()")
 	outcomes <- ieugwasr::legacy_ids(unique(outcomes))
 
-	d <- ieugwasr::tophits(outcomes, pval=p1, clump=clump, r2=r2, kb=kb, force_server=FALSE, access_token=access_token)
+	d <- ieugwasr::tophits(outcomes, pval=p1, clump=clump, r2=r2, kb=kb, force_server=FALSE, opengwas_jwt=opengwas_jwt)
 
 	# d$phenotype.deprecated <- paste0(d$trait, " || ", d$consortium, " || ", d$year, " || ", d$unit)
 	if(nrow(d) == 0) return(NULL)

--- a/R/instruments.R
+++ b/R/instruments.R
@@ -9,7 +9,7 @@
 #' @param p2 Secondary clumping threshold. The default is `5e-8`.
 #' @param r2 Clumping r2 cut off. The default is `0.001`.
 #' @param kb Clumping distance cutoff. The default is `10000`.
-#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to <https://api.opengwas.io> to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param force_server Force the analysis to extract results from the server rather than the MRInstruments package.
 #'
 #' @export

--- a/R/multivariable_mr.R
+++ b/R/multivariable_mr.R
@@ -6,7 +6,7 @@
 #' @param clump_r2 The default is `0.01`.
 #' @param clump_kb The default is `10000`.
 #' @param harmonise_strictness See the `action` option of [harmonise_data()]. The default is `2`.
-#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to <https://api.opengwas.io> to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param find_proxies Look for proxies? This slows everything down but is more accurate. The default is `TRUE`.
 #' @param force_server Whether to search through pre-clumped dataset or to re-extract and clump directly from the server. The default is `FALSE`.
 #' @param pval_threshold Instrument detection p-value threshold. Default = `5e-8`

--- a/R/multivariable_mr.R
+++ b/R/multivariable_mr.R
@@ -6,7 +6,7 @@
 #' @param clump_r2 The default is `0.01`.
 #' @param clump_kb The default is `10000`.
 #' @param harmonise_strictness See the `action` option of [harmonise_data()]. The default is `2`.
-#' @param access_token Google OAuth2 access token. Used to authenticate level of access to data.
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param find_proxies Look for proxies? This slows everything down but is more accurate. The default is `TRUE`.
 #' @param force_server Whether to search through pre-clumped dataset or to re-extract and clump directly from the server. The default is `FALSE`.
 #' @param pval_threshold Instrument detection p-value threshold. Default = `5e-8`
@@ -16,13 +16,13 @@
 #'
 #' @export
 #' @return data frame in `exposure_dat` format
-mv_extract_exposures <- function(id_exposure, clump_r2=0.001, clump_kb=10000, harmonise_strictness=2, access_token = ieugwasr::check_access_token(), find_proxies=TRUE, force_server=FALSE, pval_threshold=5e-8, pop="EUR", plink_bin=NULL, bfile=NULL)
+mv_extract_exposures <- function(id_exposure, clump_r2=0.001, clump_kb=10000, harmonise_strictness=2, opengwas_jwt=ieugwasr::get_opengwas_jwt(), find_proxies=TRUE, force_server=FALSE, pval_threshold=5e-8, pop="EUR", plink_bin=NULL, bfile=NULL)
 {
 	stopifnot(length(id_exposure) > 1)
 	id_exposure <- ieugwasr::legacy_ids(id_exposure)
 
 	# Get best instruments for each exposure
-	exposure_dat <- extract_instruments(id_exposure, p1 = pval_threshold, r2 = clump_r2, kb=clump_kb, access_token = access_token, force_server=force_server)
+	exposure_dat <- extract_instruments(id_exposure, p1 = pval_threshold, r2 = clump_r2, kb=clump_kb, opengwas_jwt = opengwas_jwt, force_server=force_server)
 	temp <- exposure_dat
 	temp$id.exposure <- 1
 	temp <- temp[order(temp$pval.exposure, decreasing=FALSE), ]
@@ -32,7 +32,7 @@ mv_extract_exposures <- function(id_exposure, clump_r2=0.001, clump_kb=10000, ha
 
 
 	# Get effects of each instrument from each exposure
-	d1 <- extract_outcome_data(exposure_dat$SNP, id_exposure, access_token = access_token, proxies=find_proxies)
+	d1 <- extract_outcome_data(exposure_dat$SNP, id_exposure, opengwas_jwt = opengwas_jwt, proxies=find_proxies)
 	stopifnot(length(unique(d1$id)) == length(unique(id_exposure)))
 	d1 <- subset(d1, mr_keep.outcome)
 	d2 <- subset(d1, id.outcome != id_exposure[1])

--- a/R/query.R
+++ b/R/query.R
@@ -1,14 +1,14 @@
 
 #' Get list of studies with available GWAS summary statistics through API
 #'
-#' @param access_token Google OAuth2 access token. Used to authenticate level of access to data
-#'
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.#'
+#' 
 #' @export
 #' @return Dataframe of details for all available studies
-available_outcomes <- function(access_token = ieugwasr::check_access_token())
+available_outcomes <- function(opengwas_jwt = ieugwasr::get_opengwas_jwt())
 {
 	# .Deprecated("ieugwasr::gwasinfo()")
-	a <- ieugwasr::gwasinfo(access_token=access_token)	
+	a <- ieugwasr::gwasinfo(opengwas_jwt=opengwas_jwt)	
 	return(a)
 }
 
@@ -25,19 +25,19 @@ available_outcomes <- function(access_token = ieugwasr::check_access_token())
 #' @param align_alleles Try to align tag alleles to target alleles (if proxies = 1). `1` = yes, `0` = no. The default is `1`.
 #' @param palindromes Allow palindromic SNPs (if proxies = 1). `1` = yes, `0` = no. The default is `1`.
 #' @param maf_threshold MAF threshold to try to infer palindromic SNPs. The default is `0.3`.
-#' @param access_token Google OAuth2 access token. Used to authenticate level of access to data.
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param splitsize The default is `10000`.
 #' @param proxy_splitsize The default is `500`.
 #'
 #' @export
 #' @return Dataframe of summary statistics for all available outcomes
-extract_outcome_data <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, align_alleles = 1, palindromes = 1, maf_threshold = 0.3, access_token = ieugwasr::check_access_token(), splitsize=10000, proxy_splitsize=500)
+extract_outcome_data <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, align_alleles = 1, palindromes = 1, maf_threshold = 0.3, opengwas_jwt=ieugwasr::get_opengwas_jwt(), splitsize=10000, proxy_splitsize=500)
 {
 	# .Deprecated("ieugwasr::associations()")
 	outcomes <- ieugwasr::legacy_ids(unique(outcomes))
 
 	snps <- unique(snps)
-	firstpass <- extract_outcome_data_internal(snps, outcomes, proxies = FALSE, access_token=access_token, splitsize = splitsize)
+	firstpass <- extract_outcome_data_internal(snps, outcomes, proxies = FALSE, opengwas_jwt=opengwas_jwt, splitsize = splitsize)
 
 	if(proxies)
 	{
@@ -52,7 +52,7 @@ extract_outcome_data <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, alig
 			if(length(missedsnps)>0)
 			{
 				message("Finding proxies for ", length(missedsnps), " SNPs in outcome ", outcomes[i])
-				temp <- extract_outcome_data_internal(missedsnps, outcomes[i], proxies = TRUE, rsq, align_alleles, palindromes, maf_threshold, access_token = access_token, splitsize = proxy_splitsize)
+				temp <- extract_outcome_data_internal(missedsnps, outcomes[i], proxies = TRUE, rsq, align_alleles, palindromes, maf_threshold, opengwas_jwt = opengwas_jwt, splitsize = proxy_splitsize)
 				if(!is.null(temp))
 				{
 					firstpass <- plyr::rbind.fill(firstpass, temp)
@@ -66,7 +66,7 @@ extract_outcome_data <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, alig
 
 
 
-extract_outcome_data_internal <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, align_alleles = 1, palindromes = 1, maf_threshold = 0.3, access_token = ieugwasr::check_access_token(), splitsize=10000)
+extract_outcome_data_internal <- function(snps, outcomes, proxies = TRUE, rsq = 0.8, align_alleles = 1, palindromes = 1, maf_threshold = 0.3, opengwas_jwt=ieugwasr::get_opengwas_jwt(), splitsize=10000)
 {
 	snps <- unique(snps)
 	message("Extracting data for ", length(snps), " SNP(s) from ", length(unique(outcomes)), " GWAS(s)")
@@ -93,7 +93,7 @@ extract_outcome_data_internal <- function(snps, outcomes, proxies = TRUE, rsq = 
 			align_alleles = align_alleles,
 			palindromes = palindromes,
 			maf_threshold = maf_threshold,
-			access_token=access_token
+			opengwas_jwt=opengwas_jwt
 		)
 		if(!is.data.frame(d)) d <- data.frame()
 
@@ -119,7 +119,7 @@ extract_outcome_data_internal <- function(snps, outcomes, proxies = TRUE, rsq = 
 					align_alleles = align_alleles,
 					palindromes = palindromes,
 					maf_threshold = maf_threshold,
-					access_token=access_token
+					opengwas_jwt=opengwas_jwt
 				)
 				if(!is.data.frame(out)) out <- data.frame()
 				return(out)
@@ -150,7 +150,7 @@ extract_outcome_data_internal <- function(snps, outcomes, proxies = TRUE, rsq = 
 					align_alleles = align_alleles,
 					palindromes = palindromes,
 					maf_threshold = maf_threshold,
-					access_token=access_token
+					opengwas_jwt=opengwas_jwt
 				)
 
 				if(!is.data.frame(out)) out <- data.frame()

--- a/R/query.R
+++ b/R/query.R
@@ -1,7 +1,7 @@
 
 #' Get list of studies with available GWAS summary statistics through API
 #'
-#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.#'
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to <https://api.opengwas.io> to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' 
 #' @export
 #' @return Dataframe of details for all available studies
@@ -25,7 +25,7 @@ available_outcomes <- function(opengwas_jwt = ieugwasr::get_opengwas_jwt())
 #' @param align_alleles Try to align tag alleles to target alleles (if proxies = 1). `1` = yes, `0` = no. The default is `1`.
 #' @param palindromes Allow palindromic SNPs (if proxies = 1). `1` = yes, `0` = no. The default is `1`.
 #' @param maf_threshold MAF threshold to try to infer palindromic SNPs. The default is `0.3`.
-#' @param opengwas_jwt Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
+#' @param opengwas_jwt Used to authenticate protected endpoints. Login to <https://api.opengwas.io> to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.
 #' @param splitsize The default is `10000`.
 #' @param proxy_splitsize The default is `500`.
 #'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,9 +2,9 @@
 
         packageStartupMessage(
                 paste("TwoSampleMR version", utils::packageVersion("TwoSampleMR"), "\n"),
-                "[>] New: Option to use non-European LD reference panels for clumping etc\n",
-                "[>] Some studies temporarily quarantined to verify effect allele\n",
-                "[>] See news(package = 'TwoSampleMR') and https://gwas.mrcieu.ac.uk for further details\n"
+                "[>] New: Improved API performance and stability\n",
+				"[>] New: Authentication required for all OpenGWAS queries from 1st May 2024\n",
+				"[>] For guidance see https://mrcieu.github.io/ieugwasr/articles/guide.html#authentication\n"
         )
 
 	a <- suppressWarnings(try(readLines("https://raw.githubusercontent.com/MRCIEU/TwoSampleMR/master/DESCRIPTION"), silent=TRUE))

--- a/inst/sandpit/multivariable_mr.R
+++ b/inst/sandpit/multivariable_mr.R
@@ -5,8 +5,8 @@ library(knitr)
 load_all()
 
 
-lipids <- mv_extract_exposures(c(299,300,302), access_token=NULL)
-chd <- extract_outcome_data(lipids$SNP, 7, access_token = NULL)
+lipids <- mv_extract_exposures(c(299,300,302))
+chd <- extract_outcome_data(lipids$SNP, 7)
 control <- mv_harmonise_data(lipids, chd)
 ```
 
@@ -45,8 +45,8 @@ kable(mv_multiple(control, intercept=FALSE, instrument_specific=FALSE)$result)
 
 
 ```{r}
-a <- mv_extract_exposures(c("UKB-a:196", 1001), access_token=NULL)
-b <- extract_outcome_data(a$SNP, 297, access_token = NULL)
+a <- mv_extract_exposures(c("UKB-a:196", 1001))
+b <- extract_outcome_data(a$SNP, 297)
 dat <- mv_harmonise_data(a, b)
 ```
 

--- a/inst/sandpit/multivariable_mr.rmd
+++ b/inst/sandpit/multivariable_mr.rmd
@@ -5,8 +5,8 @@ library(knitr)
 load_all()
 
 
-lipids <- mv_extract_exposures(c(299,300,302), access_token=NULL)
-chd <- extract_outcome_data(lipids$SNP, 7, access_token = NULL)
+lipids <- mv_extract_exposures(c(299,300,302))
+chd <- extract_outcome_data(lipids$SNP, 7)
 control <- mv_harmonise_data(lipids, chd)
 ```
 
@@ -45,8 +45,8 @@ kable(mv_multiple(control, intercept=FALSE, instrument_specific=FALSE)$result)
 
 
 ```{r}
-a <- mv_extract_exposures(c("UKB-a:196", 1001), access_token=NULL)
-b <- extract_outcome_data(a$SNP, 297, access_token = NULL)
+a <- mv_extract_exposures(c("UKB-a:196", 1001))
+b <- extract_outcome_data(a$SNP, 297)
 dat <- mv_harmonise_data(a, b)
 ```
 

--- a/man/available_outcomes.Rd
+++ b/man/available_outcomes.Rd
@@ -7,7 +7,7 @@
 available_outcomes(opengwas_jwt = ieugwasr::get_opengwas_jwt())
 }
 \arguments{
-\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.#'}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to \url{https://api.opengwas.io} to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 }
 \value{
 Dataframe of details for all available studies

--- a/man/available_outcomes.Rd
+++ b/man/available_outcomes.Rd
@@ -4,10 +4,10 @@
 \alias{available_outcomes}
 \title{Get list of studies with available GWAS summary statistics through API}
 \usage{
-available_outcomes(access_token = ieugwasr::check_access_token())
+available_outcomes(opengwas_jwt = ieugwasr::get_opengwas_jwt())
 }
 \arguments{
-\item{access_token}{Google OAuth2 access token. Used to authenticate level of access to data}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.#'}
 }
 \value{
 Dataframe of details for all available studies

--- a/man/extract_instruments.Rd
+++ b/man/extract_instruments.Rd
@@ -11,7 +11,7 @@ extract_instruments(
   p2 = 5e-08,
   r2 = 0.001,
   kb = 10000,
-  access_token = ieugwasr::check_access_token(),
+  opengwas_jwt = ieugwasr::get_opengwas_jwt(),
   force_server = FALSE
 )
 }
@@ -28,7 +28,7 @@ extract_instruments(
 
 \item{kb}{Clumping distance cutoff. The default is \code{10000}.}
 
-\item{access_token}{Google OAuth2 access token. Used to authenticate level of access to data. The default is \code{\link[ieugwasr:check_access_token]{ieugwasr::check_access_token()}}.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{force_server}{Force the analysis to extract results from the server rather than the MRInstruments package.}
 }

--- a/man/extract_instruments.Rd
+++ b/man/extract_instruments.Rd
@@ -28,7 +28,7 @@ extract_instruments(
 
 \item{kb}{Clumping distance cutoff. The default is \code{10000}.}
 
-\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to \url{https://api.opengwas.io} to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{force_server}{Force the analysis to extract results from the server rather than the MRInstruments package.}
 }

--- a/man/extract_outcome_data.Rd
+++ b/man/extract_outcome_data.Rd
@@ -32,7 +32,7 @@ extract_outcome_data(
 
 \item{maf_threshold}{MAF threshold to try to infer palindromic SNPs. The default is \code{0.3}.}
 
-\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to \url{https://api.opengwas.io} to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{splitsize}{The default is \code{10000}.}
 

--- a/man/extract_outcome_data.Rd
+++ b/man/extract_outcome_data.Rd
@@ -12,7 +12,7 @@ extract_outcome_data(
   align_alleles = 1,
   palindromes = 1,
   maf_threshold = 0.3,
-  access_token = ieugwasr::check_access_token(),
+  opengwas_jwt = ieugwasr::get_opengwas_jwt(),
   splitsize = 10000,
   proxy_splitsize = 500
 )
@@ -32,7 +32,7 @@ extract_outcome_data(
 
 \item{maf_threshold}{MAF threshold to try to infer palindromic SNPs. The default is \code{0.3}.}
 
-\item{access_token}{Google OAuth2 access token. Used to authenticate level of access to data.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{splitsize}{The default is \code{10000}.}
 

--- a/man/mv_extract_exposures.Rd
+++ b/man/mv_extract_exposures.Rd
@@ -9,7 +9,7 @@ mv_extract_exposures(
   clump_r2 = 0.001,
   clump_kb = 10000,
   harmonise_strictness = 2,
-  access_token = ieugwasr::check_access_token(),
+  opengwas_jwt = ieugwasr::get_opengwas_jwt(),
   find_proxies = TRUE,
   force_server = FALSE,
   pval_threshold = 5e-08,
@@ -27,7 +27,7 @@ mv_extract_exposures(
 
 \item{harmonise_strictness}{See the \code{action} option of \code{\link[=harmonise_data]{harmonise_data()}}. The default is \code{2}.}
 
-\item{access_token}{Google OAuth2 access token. Used to authenticate level of access to data.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{find_proxies}{Look for proxies? This slows everything down but is more accurate. The default is \code{TRUE}.}
 

--- a/man/mv_extract_exposures.Rd
+++ b/man/mv_extract_exposures.Rd
@@ -27,7 +27,7 @@ mv_extract_exposures(
 
 \item{harmonise_strictness}{See the \code{action} option of \code{\link[=harmonise_data]{harmonise_data()}}. The default is \code{2}.}
 
-\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to https://api.opengwas.io to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
+\item{opengwas_jwt}{Used to authenticate protected endpoints. Login to \url{https://api.opengwas.io} to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.}
 
 \item{find_proxies}{Look for proxies? This slows everything down but is more accurate. The default is \code{TRUE}.}
 

--- a/tests/testthat/test_mvmr_local.R
+++ b/tests/testthat/test_mvmr_local.R
@@ -15,8 +15,8 @@ test_that("mv exposure local", {
 	skip_on_cran()
     f1 <- tempfile()
     f2 <- tempfile()
-    write.table(a1, file=f1, row=F, col=T, qu=F, sep="\t")
-    write.table(a2, file=f2, row=F, col=T, qu=F, sep="\t")
+    write.table(a1, file=f1, row.names = FALSE, col.names = TRUE, quote = FALSE, sep="\t")
+    write.table(a2, file=f2, row.names = FALSE, col.names = TRUE, quote = FALSE, sep="\t")
 
     exposure_dat <- mv_extract_exposures_local(
         c(f1, f2),

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -87,11 +87,13 @@ Each step is documented on other pages in the documentation.
 
 ## Authentication
 
-**The authentication method has changed recently due to the GoogleAuthR method changing.** The main differences are that:
+The statistical methods in TwoSampleMR can be used on any data, but there are a number of functions that connect to the OpenGWAS database for data extraction. These OpenGWAS data access functions require authentication.
 
-1. By default you will not be asked to authenticate and will only have access to public data
-2. If you do need to authenticate in order to access private datasets there is no longer a single file called `mrbase.oauth`, rather, there is a directory called `ieugwasr_oauth`.
+**Authentication is changing** The main differences are that:
 
-Detailed information is given here: <https://mrcieu.github.io/ieugwasr/articles/guide.html#authentication>
+1. Authentication is required for most queries to OpenGWAS for everyone (i.e. no more anonymous usage)
+2. We are no longer using Google Oauth2. This has been replaced by a simple API key system.
+
+Detailed information is given here: <https://mrcieu.github.io/ieugwasr/articles/guide.html#authentication>. 
 
 ## References


### PR DESCRIPTION
This PR updates the package to use ieugwasr 1.0.0, which moves away from google oauth2 and now uses OpenGWAS jwt for authentication / authorisation. ieugwasr 1.0.0 has been submitted to CRAN.

It's a breaking change as previously anonymous usage was possible, and private dataset access was enabled through google authentication. Also, we're no longer using the GoogleAuthR package which might be removed from CRAN - https://cran.r-project.org/web/checks/check_results_googleAuthR.html. 