### PR TITLE
TwoSampleMR 0.6.1

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -19,7 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-14, r: 'release'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -50,7 +50,7 @@ jobs:
           extra-packages: >
             any::rcmdcheck,
             randomForest=?ignore-before-r=4.1.0,
-            car=?ignore-before-r=4.1.0,
+            car=?ignore-before-r=4.4.0,
             MendelianRandomization=?ignore-before-r=4.4.0
           needs: check
 

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'release'}
           - {os: macos-13, r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -27,6 +27,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: 'oldrel-2'}
           - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
+          - {os: macos-13, r: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -51,6 +51,7 @@ jobs:
             any::rcmdcheck,
             randomForest=?ignore-before-r=4.1.0,
             car=?ignore-before-r=4.1.0,
+            MendelianRandomization=?ignore-before-r=4.4.0
           needs: check
 
       - name: Create and populate .Renviron file

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,6 @@ Imports:
     lattice,
     magrittr,
     MASS,
-    MendelianRandomization,
     meta,
     mr.raps,
     MRMix,
@@ -56,6 +55,7 @@ Suggests:
     Cairo,
     car,
     markdown,
+    MendelianRandomization,
     MRInstruments,
     randomForest,
     testthat

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MR Base Database
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TwoSampleMR v0.6.1
+
+(Release date: 2024-04-30)
+
+* The **MendelianRandomization** package has been moved from a hard dependency to a soft dependency. This is because its dependency package **Matrix** now requires R >= 4.4.0. Making **MendelianRandomization** a soft dependency means we don't need to make TwoSampleMR have the same requirement.
+
 # TwoSampleMR v0.6.0
 
 (Release date: 2024-04-22)

--- a/R/other_formats.R
+++ b/R/other_formats.R
@@ -12,6 +12,12 @@
 #' @return List of MRInput objects for each exposure/outcome combination
 dat_to_MRInput <- function(dat, get_correlations=FALSE, pop="EUR")
 {
+  if (!requireNamespace("MendelianRandomization", quietly = TRUE)) {
+    stop(
+      "Package \"MendelianRandomization\" must be installed to use this function.",
+      call. = FALSE
+    )
+  }
 	out <- plyr::dlply(dat, c("exposure", "outcome"), function(x)
 	{
 		x <- plyr::mutate(x)


### PR DESCRIPTION
This moves MendelianRandomization from Imports to Suggests.

This is because one of its dependencies, the [Matrix package](https://cran.r-project.org/package=Matrix), now requires R >= 4.4.0. Moving MendelianRandomization to Suggests means we don't need to make the same requirement in TwoSampleMR.

There are also some tweaks to the GHA runners (adding Intel macOS, and going back another oldrel version due to the recent release of R 4.4.0).