### PR TITLE
TwoSampleMR 0.6.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MR Base Database
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TwoSampleMR v0.6.2
+
+(Release date: 2024-05-09)
+
+* `format_data()` now errors if it detects its `dat` object is of class `'data.table'` and issues a message informing the user to make their dat object simply a `'data.frame'` (thanks to Si Fang @sifang1678)
+
 # TwoSampleMR v0.6.1
 
 (Release date: 2024-04-30)

--- a/R/format_mr_results2.R
+++ b/R/format_mr_results2.R
@@ -6,7 +6,6 @@
 #'
 #' @export
 #' @return data frame
-
 split_outcome <- function(mr_res)
 {
 	Pos<-grep("\\|\\|",mr_res$outcome) #the "||"" indicates that the outcome column was derived from summary data in MR-Base. Sometimes it wont look like this e.g. if the user has supplied their own outcomes

--- a/R/heterogeneity.R
+++ b/R/heterogeneity.R
@@ -1,5 +1,3 @@
-
-
 #' Get heterogeneity statistics
 #' 
 #' Get heterogeneity statistics.

--- a/R/mr.R
+++ b/R/mr.R
@@ -1,4 +1,3 @@
-
 #' Perform all Mendelian randomization tests
 #'
 #' @param dat Harmonised exposure and outcome data. Output from [harmonise_data()].

--- a/R/query.R
+++ b/R/query.R
@@ -1,4 +1,3 @@
-
 #' Get list of studies with available GWAS summary statistics through API
 #'
 #' @param opengwas_jwt Used to authenticate protected endpoints. Login to <https://api.opengwas.io> to obtain a jwt. Provide the jwt string here, or store in .Renviron under the keyname OPENGWAS_JWT.

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -163,7 +163,17 @@ format_data <- function(dat, type="exposure", snps=NULL, header=TRUE,
                         z_col="z", info_col="info", chr_col="chr", 
                         pos_col="pos", log_pval=FALSE)
 {
-	all_cols <- c(phenotype_col, snp_col, beta_col, se_col, eaf_col, effect_allele_col, other_allele_col, pval_col, units_col, ncase_col, ncontrol_col, samplesize_col, gene_col, id_col, z_col, info_col, chr_col, pos_col)
+
+if (inherits(dat, "data.table")) {
+  datname <- deparse(substitute(dat))
+  stop(paste0(
+    "Your ", datname, " data.frame is also of class 'data.table', ",
+    "please reformat as simply a data.frame with ", datname, " <- data.frame(",
+    datname, ") and then rerun your format_data() call."
+  ))
+}
+
+  all_cols <- c(phenotype_col, snp_col, beta_col, se_col, eaf_col, effect_allele_col, other_allele_col, pval_col, units_col, ncase_col, ncontrol_col, samplesize_col, gene_col, id_col, z_col, info_col, chr_col, pos_col)
 
 	i <- names(dat) %in% all_cols
 	if(sum(i) == 0)

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -1,5 +1,3 @@
-
-
 #' Read outcome data
 #'
 #' Reads in outcome data. Checks and organises columns for use with MR or enrichment tests.

--- a/tests/testthat/test_format_data.R
+++ b/tests/testthat/test_format_data.R
@@ -1,0 +1,47 @@
+df <- data.frame(
+  "SNP" = c("9_69001927_C_T", "9_69459263_A_G", "9_69508544_G_A"),
+  "effect_allele" = c("T", "G", "A"),
+  "other_allele" = c("C", "A", "G"),
+  "se" = c(0.01664, 0.02038, 0.04585),
+  "beta" = c(0.367464, -0.265656, 0.254032),
+  "eaf" = c(0.319894, 0.39234, 0.343751),
+  "pval" = c(0.250677, 0.498338, 0.459907),
+  "n" = c(30100, 30100, 30100),
+  "pheno_id" = c("traita", "traita", "traita")
+)
+
+df <- data.table::data.table(df)
+
+test_that("format_data() should error on a dat object of class data.table", {
+  expect_error(format_data(
+    df,
+    type = "exposure",
+    snp_col = "SNP",
+    pval_col = "pval",
+    beta_col = "beta",
+    se_col = "se",
+    effect_allele_col = "effect_allele",
+    other_allele_col = "other_allele",
+    eaf_col = "eaf",
+    phenotype_col = "pheno_id",
+    samplesize_col = "n"
+  ))
+})
+
+df <- data.frame(df)
+
+test_that("format_data() should not error after having its data.table class removed", {
+  expect_no_error(format_data(
+    df,
+    type = "exposure",
+    snp_col = "SNP",
+    pval_col = "pval",
+    beta_col = "beta",
+    se_col = "se",
+    effect_allele_col = "effect_allele",
+    other_allele_col = "other_allele",
+    eaf_col = "eaf",
+    phenotype_col = "pheno_id",
+    samplesize_col = "n"
+  ))
+})


### PR DESCRIPTION
* `format_data()` now errors if it detects its `dat` object is of class `'data.table'` and issues a message informing the user to make their dat object simply a `'data.frame'` (thanks to Si Fang @sifang1678)
