### PR TITLE
Replaced some unique() calls in power_prune() with mean()

### DIFF
--- a/R/format_mr_results2.R
+++ b/R/format_mr_results2.R
@@ -311,8 +311,6 @@ power_prune <- function(dat,method=1,dist.outcome="binary")
 		id.set.unique<-unique(id.sets)
 		dat$id.set<-as.numeric(factor(id.sets))
 		for(i in seq_along(id.set.unique)){
-			print(i)
-			print(id.set.unique[i])
 			dat1<-dat[id.sets == id.set.unique[i],]
 			# unique(dat1[,c("exposure","outcome")])
 			id.subset<-paste(dat1$exposure,dat1$id.exposure,dat1$outcome,dat1$id.outcome)
@@ -344,11 +342,12 @@ power_prune <- function(dat,method=1,dist.outcome="binary")
 					iv.se<- 1/sqrt(mean(dat2$samplesize.outcome)*r2sum) #standard error of the IV should be proportional to this
 				}
 				if(dist.outcome == "binary"){
-					iv.se<-1/sqrt(mean(n.cas)*mean(n.con)*r2sum) #standard error of the IV should be proportional to this
 					if(any(is.na(n.cas)) || any(is.na(n.con))) {
 						warning("dist.outcome set to binary but number of cases or controls is missing. Will try using total sample size instead but power pruning will be less accurate")
 						iv.se<- 1/sqrt(mean(dat2$samplesize.outcome)*r2sum) 
-					}
+					} else {
+                    	iv.se<-1/sqrt(mean(n.cas)*mean(n.con)*r2sum) #standard error of the IV should be proportional to this
+                    }
 				}
 				# Power calculations to implement at some point
 				# iv.se<-1/sqrt(unique(n.cas)*unique(n.con)*r2sum) #standard error of the IV should be proportional to this

--- a/R/format_mr_results2.R
+++ b/R/format_mr_results2.R
@@ -341,13 +341,13 @@ power_prune <- function(dat,method=1,dist.outcome="binary")
 				r2sum<-sum(r2) # sum of the r-squares for each SNP in the instrument
 				# F<-r2sum*(n-1-k)/((1-r2sum*k )
 				if(dist.outcome == "continuous"){
-					iv.se<- 1/sqrt(unique(dat2$samplesize.outcome)*r2sum) #standard error of the IV should be proportional to this
+					iv.se<- 1/sqrt(mean(dat2$samplesize.outcome)*r2sum) #standard error of the IV should be proportional to this
 				}
 				if(dist.outcome == "binary"){
-					iv.se<-1/sqrt(unique(n.cas)*unique(n.con)*r2sum) #standard error of the IV should be proportional to this
+					iv.se<-1/sqrt(mean(n.cas)*mean(n.con)*r2sum) #standard error of the IV should be proportional to this
 					if(any(is.na(n.cas)) || any(is.na(n.con))) {
 						warning("dist.outcome set to binary but number of cases or controls is missing. Will try using total sample size instead but power pruning will be less accurate")
-						iv.se<- 1/sqrt(unique(dat2$samplesize.outcome)*r2sum) 
+						iv.se<- 1/sqrt(mean(dat2$samplesize.outcome)*r2sum) 
 					}
 				}
 				# Power calculations to implement at some point


### PR DESCRIPTION
This ensures that iv.se will be a scalar not a vector even when the outcome.samplesize varies within outcome subsets.

The current behavior assumes that the samplesize is the same within each outcome subset, and that unique will therefore return a scalar. When this assumption is violated, it returns a vector of samplesize values that is likely to differ in length from the total size of the subset and will therefore produce a size mismatch when assigning it as a column in that data.frame. 

Removing the unique() call and allowing iv.se to be a vector of the size of the outcome subset will not produce an error but it will cause the outcome subsets to be selected according to the largest samplesize among any of the IV SNPs in that subset, which is not the desired behavior.

Using the mean() of the samplesize ensures that iv.se is the same for every SNP in the outcome subset (and that the selection logic will therefore work properly) while taking into account all the SNPs in the subset.