### PR TITLE
Keep the perform_mr vignette building on R 4.3.3 and 4.3.2 

### DIFF
--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -633,7 +633,7 @@ ld_mat
 
 Here `ld_matrix()` returns the LD correlation values (not R^2^) for each pair of variants present in the 1000 genomes data set.
 
-```{r}
+```{r eval=FALSE}
 dat <- harmonise_data(
   exposure_dat = bmi_exp_dat,
   outcome_dat = chd_out_dat
@@ -642,7 +642,7 @@ dat <- harmonise_data(
 
 Convert to the `MRInput` format for the MendelianRandomization package:
 
-```{r}
+```{r eval=FALSE}
 dat2 <- dat_to_MRInput(dat)
 ```
 


### PR DESCRIPTION
By not evaluating two chunks, the second of which prevents the MendelianRandomization package from loading (as one of its dependencies requires R >= 4.4.0).