### PR TITLE
Add check on Ubuntu Linux 24.04 on ARM

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -35,6 +35,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
           - {os: ubuntu-latest,   r: '4.3.2'}
+          - {os: ubuntu-24.04-arm, r: 'release', rspm: 'no' }
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +51,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+          use-public-rspm: ${{ matrix.config.rspm || 'true' }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/TwoSampleMR.Rproj
+++ b/TwoSampleMR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: d383bef4-4f42-4ddf-b7bd-5ce276e0bb41
 
 RestoreWorkspace: Default
 SaveWorkspace: Default


### PR DESCRIPTION
I have building the docker image as multi-platform for a while (i.e., both x96_64 and ARM), so I know that TwoSampleMR builds on Linux on ARM.

https://github.com/MRCIEU/docker_twosamplemr

And GitHub now has Ubuntu on ARM on the free plan: 
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/