### PR TITLE
TwoSampleMR 0.6.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MR Base Database
-Version: 0.6.8
+Version: 0.6.9
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: TwoSampleMR
-Title: Two Sample MR Functions and Interface to MR Base Database
+Title: Two Sample MR Functions and Interface to MRC Integrative Epidemiology Unit OpenGWAS Database
 Version: 0.6.9
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-4655-4511"))
   )
 Description: A package for performing Mendelian randomization using GWAS
-    summary data. It uses the IEU GWAS database
+    summary data. It uses the IEU OpenGWAS database
     <https://gwas.mrcieu.ac.uk/> to automatically obtain data, and a wide
     range of methods to run the analysis.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,7 @@ Authors@R: c(
 Description: A package for performing Mendelian randomization using GWAS
     summary data. It uses the IEU GWAS database
     <https://gwas.mrcieu.ac.uk/> to automatically obtain data, and a wide
-    range of methods to run the analysis. You can use the MR-Base web app
-    <https://www.mrbase.org/> to try out a limited range of the
-    functionality in this package, but for any serious work we strongly
-    recommend using this R package.
+    range of methods to run the analysis.
 License: MIT + file LICENSE
 URL: https://github.com/MRCIEU/TwoSampleMR,
     https://mrcieu.github.io/TwoSampleMR/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# TwoSampleMR v0.6.9
+
+(Release date 2025-02-05)
+
+
 # TwoSampleMR v0.6.8
 
 (Release date 2024-09-06)

--- a/NEWS.md
+++ b/NEWS.md
@@ -336,5 +336,4 @@ TwoSampleMR v0.3.1
 (Release date: 2017-11-22)
 
 * One of the external packages that TwoSampleMR depends upon had changed, making the authorisation behaviour change. The authorisation was timing out after an hour and it was not refreshing after its timeout. This has now been fixed - the authorisation token will refresh after an hour.
-
 * The authorisation token used to be stored in a hidden file called .httr-oauth. This has now been changed - it will be stored in a visible file called 'mrbase.oauth'.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Fixed a bug in `format_data()` when the `log_pval` argument was set to `TRUE`.
 The specified p-value column is now used (thanks to @luddeluddis)
+* Amend references to MR-Base to OpenGWAS
 
 # TwoSampleMR v0.6.8
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 (Release date 2025-02-05)
 
+* Fixed a bug in `format_data()` when the `log_pval` argument was set to `TRUE`.
+The specified p-value column is now used (thanks to @luddeluddis)
 
 # TwoSampleMR v0.6.8
 

--- a/R/forest_plot2.R
+++ b/R/forest_plot2.R
@@ -11,10 +11,10 @@
 #'
 #' By default it uses the [available_outcomes()] function to retrieve the study level characteristics for the outcome trait,
 #' including sample size and outcome category.
-#' This assumes the MR analysis was performed using outcome GWAS(s) contained in MR-Base.
+#' This assumes the MR analysis was performed using outcome GWAS(s) contained in OpenGWAS.
 #'
 #' If \code{ao_slc} is set to \code{TRUE} then the user must supply their own study level characteristics.
-#' This is useful when the user has supplied their own outcome GWAS results (i.e. they are not in MR-Base).
+#' This is useful when the user has supplied their own outcome GWAS results (i.e. they are not in OpenGWAS).
 #'
 #' @param mr_res Results from [mr()].
 #' @param exponentiate Convert effects to OR? The default is `FALSE`.

--- a/R/instruments.R
+++ b/R/instruments.R
@@ -1,4 +1,4 @@
-#' Find instruments for use in MR from the MR Base database
+#' Find instruments for use in MR from the OpenGWAS database
 #'
 #' This function searches for GWAS significant SNPs (for a given p-value) for a specified set of outcomes.
 #' It then performs LD based clumping to return only independent significant associations.

--- a/R/other_formats.R
+++ b/R/other_formats.R
@@ -5,7 +5,7 @@
 #' function converts from the TwoSampleMR format to the MRInput class.
 #'
 #' @param dat Output from the [harmonise_data()] function.
-#' @param get_correlations Default `FALSE`. If `TRUE` then extract the LD matrix for the SNPs from the European 1000 genomes data on the MR-Base server.
+#' @param get_correlations Default `FALSE`. If `TRUE` then extract the LD matrix for the SNPs from the European 1000 genomes data on OpenGWAS.
 #' @param pop If `get_correlations` is `TRUE` then use the following
 #'
 #' @export

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -212,7 +212,7 @@ if (inherits(dat, "data.table")) {
 
 	if(log_pval)
 	{
-		dat$pval <- 10^-dat[[pval_col]]
+		dat[[pval_col]] <- 10^-dat[[pval_col]]
 	}
 
 	# Remove duplicated SNPs

--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ badge](https://mrcieu.r-universe.dev/badges/TwoSampleMR)](https://mrcieu.r-unive
 <!-- badges: end -->
 
 A package for performing Mendelian randomization using GWAS summary
-data. It uses the [IEU GWAS database](https://gwas.mrcieu.ac.uk/) to
+data. It uses the [IEU OpenGWAS database](https://gwas.mrcieu.ac.uk/) to
 obtain data automatically, and a wide range of methods to run the
-analysis. You can use the [MR-Base web app](https://www.mrbase.org/) to
-try out a limited range of the functionality in this package, but for
-any serious work we strongly recommend using this R package.
+analysis.
 
 ## January 2020 major update
 
@@ -54,8 +52,9 @@ To update the package just run the
 
 ## Docker
 
-A docker image containing R with the TwoSampleMR package pre-installed
-is available here: <https://hub.docker.com/r/mrcieu/twosamplemr>
+A multi-platform docker image containing R with the TwoSampleMR package
+pre-installed (for both x86_64 and ARM computers) is available here:
+<https://hub.docker.com/r/mrcieu/twosamplemr>
 
 <!-- Additional content -->
 

--- a/index.md
+++ b/index.md
@@ -36,4 +36,4 @@ To update the package just run the `remotes::install_github("MRCIEU/TwoSampleMR"
 
 ## Docker
 
-A docker image containing R with the TwoSampleMR package pre-installed is available here: https://hub.docker.com/r/mrcieu/twosamplemr
+A multi-platform docker image containing R with the TwoSampleMR package pre-installed (for both x86_64 and ARM computers) is available here: https://hub.docker.com/r/mrcieu/twosamplemr

--- a/index.md
+++ b/index.md
@@ -7,7 +7,7 @@
 [![TwoSampleMR status badge](https://mrcieu.r-universe.dev/badges/TwoSampleMR)](https://mrcieu.r-universe.dev/TwoSampleMR)
 <!-- badges: end -->
 
-A package for performing Mendelian randomization using GWAS summary data. It uses the [IEU GWAS database](https://gwas.mrcieu.ac.uk/) to obtain data automatically, and a wide range of methods to run the analysis. You can use the [MR-Base web app](https://www.mrbase.org/) to try out a limited range of the functionality in this package, but for any serious work we strongly recommend using this R package.
+A package for performing Mendelian randomization using GWAS summary data. It uses the [IEU OpenGWAS database](https://gwas.mrcieu.ac.uk/) to obtain data automatically, and a wide range of methods to run the analysis.
 
 ## January 2020 major update 
 

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,6 +1,6 @@
 c(
 bibentry(
-  header = "If using MR-Base, the IEU GWAS database, or the TwoSampleMR R package please cite:",
+  header = "If using MR-Base, the IEU OpenGWAS database, or the TwoSampleMR R package please cite:",
   bibtype = "Article",
   author = c(
     person("G.", "Hemani", role = c("aut", "cre")),

--- a/man/TwoSampleMR-package.Rd
+++ b/man/TwoSampleMR-package.Rd
@@ -4,9 +4,9 @@
 \name{TwoSampleMR-package}
 \alias{TwoSampleMR}
 \alias{TwoSampleMR-package}
-\title{TwoSampleMR: Two Sample MR Functions and Interface to MR Base Database}
+\title{TwoSampleMR: Two Sample MR Functions and Interface to MRC Integrative Epidemiology Unit OpenGWAS Database}
 \description{
-A package for performing Mendelian randomization using GWAS summary data. It uses the IEU GWAS database \url{https://gwas.mrcieu.ac.uk/} to automatically obtain data, and a wide range of methods to run the analysis. You can use the MR-Base web app \url{https://www.mrbase.org/} to try out a limited range of the functionality in this package, but for any serious work we strongly recommend using this R package.
+A package for performing Mendelian randomization using GWAS summary data. It uses the IEU OpenGWAS database \url{https://gwas.mrcieu.ac.uk/} to automatically obtain data, and a wide range of methods to run the analysis.
 }
 \seealso{
 Useful links:

--- a/man/dat_to_MRInput.Rd
+++ b/man/dat_to_MRInput.Rd
@@ -9,7 +9,7 @@ dat_to_MRInput(dat, get_correlations = FALSE, pop = "EUR")
 \arguments{
 \item{dat}{Output from the \code{\link[=harmonise_data]{harmonise_data()}} function.}
 
-\item{get_correlations}{Default \code{FALSE}. If \code{TRUE} then extract the LD matrix for the SNPs from the European 1000 genomes data on the MR-Base server.}
+\item{get_correlations}{Default \code{FALSE}. If \code{TRUE} then extract the LD matrix for the SNPs from the European 1000 genomes data on OpenGWAS.}
 
 \item{pop}{If \code{get_correlations} is \code{TRUE} then use the following}
 }

--- a/man/extract_instruments.Rd
+++ b/man/extract_instruments.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/instruments.R
 \name{extract_instruments}
 \alias{extract_instruments}
-\title{Find instruments for use in MR from the MR Base database}
+\title{Find instruments for use in MR from the OpenGWAS database}
 \usage{
 extract_instruments(
   outcomes,

--- a/man/format_mr_results.Rd
+++ b/man/format_mr_results.Rd
@@ -42,8 +42,8 @@ It creates a new data frame with the following:
 \details{
 By default it uses the \code{\link[=available_outcomes]{available_outcomes()}} function to retrieve the study level characteristics for the outcome trait,
 including sample size and outcome category.
-This assumes the MR analysis was performed using outcome GWAS(s) contained in MR-Base.
+This assumes the MR analysis was performed using outcome GWAS(s) contained in OpenGWAS.
 
 If \code{ao_slc} is set to \code{TRUE} then the user must supply their own study level characteristics.
-This is useful when the user has supplied their own outcome GWAS results (i.e. they are not in MR-Base).
+This is useful when the user has supplied their own outcome GWAS results (i.e. they are not in OpenGWAS).
 }

--- a/vignettes/exposure.Rmd
+++ b/vignettes/exposure.Rmd
@@ -279,9 +279,9 @@ cg25212131_exp_dat <-
                              age == "Birth"))
 ```
 
-### IEU GWAS database
+### IEU OpenGWAS database
 
-The IEU GWAS database contains the entire summary statistics for thousands of GWASs. You can browse them here: https://gwas.mrcieu.ac.uk/
+The IEU OpenGWAS database contains the entire summary statistics for thousands of GWASs. You can browse them here: https://gwas.mrcieu.ac.uk/
 
 You can use this database to define the instruments for a particular exposure. You can also use this database to obtain the effects for constructing polygenic risk scores using different p-value thresholds.
 
@@ -350,7 +350,7 @@ By changing changing the `p1` parameter it is possible to obtain SNP effects for
 
 ## Clumping
 
-For standard two sample MR it is important to ensure that the instruments for the exposure are independent. Once instruments have been identified for an exposure variable, the IEU GWAS database can be used to perform clumping.
+For standard two sample MR it is important to ensure that the instruments for the exposure are independent. Once instruments have been identified for an exposure variable, the IEU OpenGWAS database can be used to perform clumping.
 
 You can provide a list of SNP IDs, the SNPs will be extracted from 1000 genomes data, LD calculated between them, and amongst those SNPs that have LD R-square above the specified threshold only the SNP with the lowest P-value will be retained. To do this, use the following command:
 


### PR DESCRIPTION
* Fixed a bug in `format_data()` when the `log_pval` argument was set to `TRUE`.
The specified p-value column is now used (thanks to @luddeluddis)
* Amend references to MR-Base to OpenGWAS

Closes #586 