### PR TITLE
Drop exposure SNPs that fail harmonisation in MVMR

### DIFF
--- a/R/multivariable_mr.R
+++ b/R/multivariable_mr.R
@@ -41,6 +41,9 @@ mv_extract_exposures <- function(id_exposure, clump_r2=0.001, clump_kb=10000, ha
 	# Harmonise against the first id
 	d <- harmonise_data(d1, d2, action=harmonise_strictness)
 
+	# Drop SNPs that do not pass harmonisation (e.g. palindromic)
+	d <- subset(d, mr_keep)
+
 	# Only keep SNPs that are present in all
 	tab <- table(d$SNP)
 	keepsnps <- names(tab)[tab == length(id_exposure)-1]
@@ -223,6 +226,9 @@ mv_extract_exposures_local <- function(
 
 	# Harmonise against the first id
 	d <- harmonise_data(d1, d2, action=harmonise_strictness)
+
+	# Drop SNPs that do not pass harmonisation (e.g. palindromic)
+	d <- subset(d, mr_keep)
 
 	# Only keep SNPs that are present in all
 	tab <- table(d$SNP)


### PR DESCRIPTION
I believe this is a bug, however if it is a deliberate design choice then please ignore.

When harmonising the exposures with each other in MVMR, SNPs that are not present in all datasets are removed, as expected; however, SNPs that are palindromic/not inferable are not removed. This occurs in both `mv_extract_exposures` and `mv_extract_exposures_local`.

In `mv_harmonise_data`, SNPs that are palindromic/not inferable between the first exposure and outcome are correctly removed.