### PR TITLE
TwoSampleMR v0.6.11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,6 @@ Suggests:
     mr.raps,
     MRInstruments,
     randomForest,
-    rsnps,
     testthat,
     tidyr
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MRC Integrative
     Epidemiology Unit OpenGWAS Database
-Version: 0.6.10
+Version: 0.6.11
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# TwoSampleMR v0.6.11
+
+(Release date 2025-03-06)
+
+* The tests using **mr.raps** are now run conditionally.
+* The **rsnps** package has been removed from Suggests because the configuration of **mr.raps** has been corrected.
+
 # TwoSampleMR v0.6.10
 
 (Release date 2025-03-03)

--- a/tests/testthat/test_mr.R
+++ b/tests/testthat/test_mr.R
@@ -15,6 +15,7 @@ test_that("Test mr(): MR Egger, Weighted median, Inverse variance weighted, Simp
 })
 
 test_that("mr.raps", {
+  skip_if_not_installed("mr.raps")
   res2 <- suppressWarnings(mr(dat, method_list = "mr_raps"))
   expect_equal(nrow(res2), 1L)
   expect_equal(ncol(res2), 9L)
@@ -22,6 +23,7 @@ test_that("mr.raps", {
 })
 
 test_that("mr.raps over.dispersion option", {
+  skip_if_not_installed("mr.raps")
   params <- default_parameters()
   params$over.dispersion <- FALSE
   res3 <- suppressWarnings(mr(dat, method_list = "mr_raps", parameters = params))
@@ -31,6 +33,7 @@ test_that("mr.raps over.dispersion option", {
 })
 
 test_that("mr.raps loss.function option", {
+  skip_if_not_installed("mr.raps")
   params <- default_parameters()
   params$loss.function <- "tukey"
   res4 <- suppressWarnings(mr(dat, method_list = "mr_raps", parameters = params))
@@ -40,6 +43,7 @@ test_that("mr.raps loss.function option", {
 })
 
 test_that("mr.raps shrinkage option", {
+  skip_if_not_installed("mr.raps")
   params <- default_parameters()
   params$shrinkage <- TRUE
   res5 <- suppressWarnings(mr(dat, method_list = "mr_raps", parameters = params))


### PR DESCRIPTION
* The tests using **mr.raps** are now run conditionally.
* The **rsnps** package has been removed from Suggests because the configuration of **mr.raps** has been corrected.
