### PR TITLE
TwoSampleMR v0.6.12

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MRC Integrative
     Epidemiology Unit OpenGWAS Database
-Version: 0.6.11
+Version: 0.6.12
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# TwoSampleMR v0.6.12
+
+(Release date 2025-03-18)
+
+* Fixed a bug in `format_data()` (thanks to @lea-urpa)
+* For MVMR data extraction in `mv_extract_exposures()` and `mv_extract_exposures_local()`, SNPs that do not pass harmonisation between exposures in MVMR are now dropped (thanks @yatest)
+* The comments about **mr.raps** in the Perform MR vignette have been updated
+
 # TwoSampleMR v0.6.11
 
 (Release date 2025-03-06)

--- a/R/mr.R
+++ b/R/mr.R
@@ -18,7 +18,7 @@ mr <- function(dat, parameters=default_parameters(), method_list=subset(mr_metho
       stop("You can install mr.raps with install.packages('mr.raps', repos = c('https://mrcieu.r-universe.dev', 'https://cloud.r-project.org'))")
     }
   }
-  
+
 	mr_tab <- plyr::ddply(dat, c("id.exposure", "id.outcome"), function(x1)
 	{
 		# message("Performing MR analysis of '", x1$id.exposure[1], "' on '", x18WII58$id.outcome[1], "'")
@@ -984,7 +984,7 @@ mr_raps <- function(b_exp, b_out, se_exp, se_out, parameters = default_parameter
   if (!(requireNamespace("mr.raps", quietly = TRUE))) {
     stop("You can install mr.raps with install.packages('mr.raps', repos = c('https://mrcieu.r-universe.dev', 'https://cloud.r-project.org'))")
   }
-  
+
     data <- data.frame(beta.exposure = b_exp,
                        beta.outcome = b_out,
                        se.exposure = se_exp,

--- a/R/multivariable_mr.R
+++ b/R/multivariable_mr.R
@@ -41,6 +41,9 @@ mv_extract_exposures <- function(id_exposure, clump_r2=0.001, clump_kb=10000, ha
 	# Harmonise against the first id
 	d <- harmonise_data(d1, d2, action=harmonise_strictness)
 
+	# Drop SNPs that do not pass harmonisation (e.g. palindromic)
+	d <- subset(d, mr_keep)
+
 	# Only keep SNPs that are present in all
 	tab <- table(d$SNP)
 	keepsnps <- names(tab)[tab == length(id_exposure)-1]
@@ -223,6 +226,9 @@ mv_extract_exposures_local <- function(
 
 	# Harmonise against the first id
 	d <- harmonise_data(d1, d2, action=harmonise_strictness)
+
+	# Drop SNPs that do not pass harmonisation (e.g. palindromic)
+	d <- subset(d, mr_keep)
 
 	# Only keep SNPs that are present in all
 	tab <- table(d$SNP)

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -196,6 +196,9 @@ if (inherits(dat, "data.table")) {
 	if(!is.null(snps))
 	{
 		dat <- subset(dat, SNP %in% snps)
+		if (nrow(dat) == 0L) {
+		  stop("No SNPs specified for the exposure are present in the outcome dataset.")
+		}
 	}
 
 	if(! phenotype_col %in% names(dat))

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 0%
+        informational: true

--- a/vignettes/perform_mr.Rmd
+++ b/vignettes/perform_mr.Rmd
@@ -482,14 +482,14 @@ dev.off()
 
 ## MR.RAPS: Many weak instruments analysis
 
-MR.RAPS (Robust Adjusted Profile Score) is a recently proposed method that considers the measurement error in SNP-exposure effects, is unbiased when there are many (e.g. hundreds of) weak instruments, and is robust to systematic and idiosyncratic pleiotropy. See the [arXiv preprint](https://arxiv.org/abs/1801.09652) for more detail about the statistical methodology.
+MR.RAPS (Robust Adjusted Profile Score) is a recently proposed method that considers the measurement error in SNP-exposure effects, is unbiased when there are many (e.g. hundreds of) weak instruments, and is robust to systematic and idiosyncratic pleiotropy. See @zhao2020 for more detail about the statistical methodology.
 
-MR.RAPS is implemented in the R package _mr.raps_ that is available on CRAN. It can be directly called from TwoSampleMR by
+MR.RAPS is implemented in the R package **mr.raps** that is available on [GitHub](https://github.com/qingyuanzhao/mr.raps) which is installed when you install TwoSampleMR. It can be directly called from TwoSampleMR by
 ```{r eval=FALSE}
 res <- mr(dat, method_list = c("mr_raps"))
 ```
 
-MR.RAPS comes with two main options: `over.dispersion` (whether the method should consider systematic pleiotropy) and `loss.function` (either `"l2"`, `"huber"`, or `"tukey"`). The latter two loss functions are robust to idiosyncratic pleiotropy. The default option is `over.dispersion = TRUE` and `loss.function = "tukey"`. To change these options, modify the `parameters` argument of `mr()` by (for example)
+MR.RAPS comes with two main options: `over.dispersion` (whether the method should consider systematic pleiotropy) and `loss.function` (either `"l2"`, `"huber"`, or `"tukey"`). The latter two loss functions are robust to idiosyncratic pleiotropy. The default option is `over.dispersion = TRUE` and `loss.function = "huber"`. To change these options, modify the `parameters` argument of `mr()` by (for example)
 ```{r eval=FALSE}
 res <-
   mr(

--- a/vignettes/refs.bib
+++ b/vignettes/refs.bib
@@ -83,3 +83,13 @@
     pages = {e1007081},
     number = {11},
 }
+
+@article{zhao2020,
+  title={{Statistical inference in two-sample summary-data Mendelian randomization using robust adjusted profile score}},
+  author={Zhao, Qingyuan and Wang, Jingshu and Hemani, Gibran and Bowden, Jack and Small, Dylan S},
+  year={2020},
+  volume = {48},
+  issue = {3},
+  pages = {1742--1769},
+  url = {https://doi.org/10.1214/19-AOS1866}
+}


### PR DESCRIPTION
* Fixed a bug in `format_data()` (thanks to @lea-urpa)
* For MVMR data extraction in `mv_extract_exposures()` and `mv_extract_exposures_local()`, SNPs that do not pass harmonisation between exposures in MVMR are now dropped (thanks @yatest)
* The comments about **mr.raps** in the Perform MR vignette have been updated

Closes #45 
Closes #592 