### PR TITLE
Add check on macos-15

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -35,6 +35,7 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-2'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: '4.3.2'}
+          - {os: macos-15, r: 'release'}
           - {os: macos-13, r: 'release'}
           # - {os: ubuntu-24.04-arm, r: 'release', rspm: 'no' }
 


### PR DESCRIPTION
It turns out `macos-latest` is still on macOS 14.