### PR TITLE
TwoSampleMR v0.6.15

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -35,6 +35,8 @@ jobs:
           - {os: ubuntu-latest,   r: 'oldrel-2'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: '4.3.2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'oldrel-4'}
           - {os: macos-15, r: 'release'}
           - {os: macos-13, r: 'release'}
           # - {os: ubuntu-24.04-arm, r: 'release', rspm: 'no' }
@@ -62,7 +64,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: >
-            any::rcmdcheck, MendelianRandomization=?ignore-before-r=4.4.0
+            any::rcmdcheck, MendelianRandomization=?ignore-before-r=4.4.0, car=?ignore-before-r=4.3.2
           needs: check
           upgrade: 'TRUE'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MRC Integrative
     Epidemiology Unit OpenGWAS Database
-Version: 0.6.14
+Version: 0.6.15
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,7 +49,7 @@ Imports:
     RadialMR,
     reshape2,
     rmarkdown
-Suggests: 
+Suggests:
     Cairo,
     car,
     markdown,
@@ -59,7 +59,7 @@ Suggests:
     randomForest,
     testthat,
     tidyr
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Remotes:
     gqi/MRMix,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ URL: https://github.com/MRCIEU/TwoSampleMR,
     https://mrcieu.github.io/TwoSampleMR/
 BugReports: https://github.com/MRCIEU/TwoSampleMR/issues/
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.1.0)
 Imports:
     cowplot,
     data.table,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TwoSampleMR v0.6.15
+
+(Release date 2025-05-01)
+
+* Bumped the minimum required version of R to 4.1.0. This is due to a dependency (the scales package) of a dependency (the ggplot2 package), which now has this requirement.
+
 # TwoSampleMR v0.6.14
 
 (Release date 2025-03-28)

--- a/inst/sandpit/test_mr_sign.R
+++ b/inst/sandpit/test_mr_sign.R
@@ -3,7 +3,7 @@
 
 # Use binomial test assuming that on average should be 50% under the null hypothesis
 
-# What is the minumum number of SNPs required to achieve p-value of 0.05?
+# What is the minimum number of SNPs required to achieve p-value of 0.05?
 
 param <- expand.grid(n = 1:100, x=0:100)
 param <- subset(param, x <= n)


### PR DESCRIPTION
* Bumped the minimum required version of R to 4.1.0. This is due to a dependency (the scales package) of a dependency (the ggplot2 package), which now has this requirement.
