### PR TITLE
Move meta to Suggests list

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -64,7 +64,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: >
-            any::rcmdcheck, MendelianRandomization=?ignore-before-r=4.4.0, car=?ignore-before-r=4.3.2, Cairo=?ignore-before-r=4.3.0
+            any::rcmdcheck, MendelianRandomization=?ignore-before-r=4.4.0, car=?ignore-before-r=4.3.2, Cairo=?ignore-before-r=4.3.0, meta=?ignore-before-r=4.4.0
           needs: check
           upgrade: 'TRUE'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TwoSampleMR
 Title: Two Sample MR Functions and Interface to MRC Integrative
     Epidemiology Unit OpenGWAS Database
-Version: 0.6.24
+Version: 0.6.25
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0920-1055")),
@@ -40,7 +40,6 @@ Imports:
     lattice,
     magrittr,
     MASS,
-    meta,
     MRMix,
     MRPRESSO,
     pbapply,
@@ -54,6 +53,7 @@ Suggests:
     car,
     markdown,
     MendelianRandomization,
+    meta,
     mr.raps,
     MRInstruments,
     randomForest,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# TwoSampleMR v0.6.25
+
+(Release date 2025-12-05)
+
+* The **meta** package has been moved to a soft (Suggests list) dependency due to installation problems of new versions of its hard dependencies on R 4.1.
+
 # TwoSampleMR v0.6.24
 
 (Release date 2025-10-31)

--- a/R/mr.R
+++ b/R/mr.R
@@ -346,6 +346,12 @@ mr_meta_fixed <- function(b_exp, b_out, se_exp, se_out, parameters) {
   if (sum(!is.na(b_exp) & !is.na(b_out) & !is.na(se_exp) & !is.na(se_out)) < 1) {
     return(list(b = NA, se = NA, pval = NA, nsnp = NA, Q = NA, Q_df = NA, Q_pval = NA))
   }
+  if (!requireNamespace("meta", quietly = TRUE)) {
+    stop(
+      "Package \"meta\" must be installed to use this function.",
+      call. = FALSE
+    )
+  }
   ratio <- b_out / b_exp
   ratio.se <- sqrt(
     (se_out^2 / b_exp^2) + (b_out^2 / b_exp^4) * se_exp^2 - 2 * (b_out / b_exp^3) * parameters$Cov
@@ -387,6 +393,14 @@ mr_meta_random <- function(b_exp, b_out, se_exp, se_out, parameters) {
   if (sum(!is.na(b_exp) & !is.na(b_out) & !is.na(se_exp) & !is.na(se_out)) < 2) {
     return(list(b = NA, se = NA, pval = NA, nsnp = NA, Q = NA, Q_df = NA, Q_pval = NA))
   }
+
+  if (!requireNamespace("meta", quietly = TRUE)) {
+    stop(
+      "Package \"meta\" must be installed to use this function.",
+      call. = FALSE
+    )
+  }
+
   ratio <- b_out / b_exp
   ratio.se <- sqrt(
     (se_out^2 / b_exp^2) + (b_out^2 / b_exp^4) * se_exp^2 - 2 * (b_out / b_exp^3) * parameters$Cov


### PR DESCRIPTION
* The **meta** package has been moved to a soft (Suggests list) dependency due to installation problems of new versions of its hard dependencies on R 4.1.